### PR TITLE
DST-720- licensing grounds legal advisory form is pre populated after CYA redirect

### DIFF
--- a/django_app/apply_for_a_licence/views/views_grounds_purpose.py
+++ b/django_app/apply_for_a_licence/views/views_grounds_purpose.py
@@ -49,14 +49,8 @@ class LicensingGroundsView(BaseFormView):
             self.request.session["licensing_grounds_legal_advisory"] = {}
             self.success_url = reverse("purpose_of_provision")
 
-        url_params = ""
-        if self.request.GET.get("redirect_to_url", ""):
-            url_params = "update=yes"
-
         if get_parameters := urllib.parse.urlencode(self.request.GET):
-            self.success_url += "?" + url_params + "&" + get_parameters
-        else:
-            self.success_url += "?" + url_params
+            self.success_url += "?" + get_parameters
 
         return self.success_url
 

--- a/django_app/apply_for_a_licence/views/views_grounds_purpose.py
+++ b/django_app/apply_for_a_licence/views/views_grounds_purpose.py
@@ -77,7 +77,8 @@ class LicensingGroundsLegalAdvisoryView(BaseFormView):
 
         if self.request.GET.get("update", ""):
             # clear the session data if the user is coming from the CYA page
-            self.request.session.pop("licensing_grounds_legal_advisory", {})
+            if self.request.session.get("licensing_grounds_legal_advisory", ""):
+                self.request.session.pop("licensing_grounds_legal_advisory")
         return kwargs
 
 

--- a/django_app/apply_for_a_licence/views/views_grounds_purpose.py
+++ b/django_app/apply_for_a_licence/views/views_grounds_purpose.py
@@ -1,4 +1,5 @@
 import logging
+import urllib
 
 from apply_for_a_licence.choices import ProfessionalOrBusinessServicesChoices
 from apply_for_a_licence.forms import forms_grounds_purpose as forms
@@ -42,11 +43,22 @@ class LicensingGroundsView(BaseFormView):
             and len(self.professional_or_business_services_data) > 1
         ):
             # the user has selected 'Legal advisory' as well as other services, redirect them to the legal advisory page
-            return reverse("licensing_grounds_legal_advisory")
+            self.success_url = reverse("licensing_grounds_legal_advisory")
         else:
             # delete form data for legal advisory grounds
             self.request.session["licensing_grounds_legal_advisory"] = {}
-            return reverse("purpose_of_provision")
+            self.success_url = reverse("purpose_of_provision")
+
+        url_params = ""
+        if self.request.GET.get("redirect_to_url", ""):
+            url_params = "update=yes"
+
+        if get_parameters := urllib.parse.urlencode(self.request.GET):
+            self.success_url += "?" + url_params + "&" + get_parameters
+        else:
+            self.success_url += "?" + url_params
+
+        return self.success_url
 
 
 class LicensingGroundsLegalAdvisoryView(BaseFormView):
@@ -68,6 +80,10 @@ class LicensingGroundsLegalAdvisoryView(BaseFormView):
         }
         if set(self.professional_or_business_services_data) == auditing_and_legal_only:
             kwargs["audit_service_selected"] = True
+
+        if self.request.GET.get("update", ""):
+            # clear the session data if the user is coming from the CYA page
+            self.request.session.pop("licensing_grounds_legal_advisory", {})
         return kwargs
 
 

--- a/django_app/core/forms/base_forms.py
+++ b/django_app/core/forms/base_forms.py
@@ -57,7 +57,7 @@ class BaseForm(forms.Form):
         self.helper.layout = Layout(*self.fields)
 
         # clearing the form data if 'change' is passed as a query parameter, and it's a GET request
-        if self.request and self.request.method == "GET" and self.request.GET.get("change"):
+        if self.request and self.request.method == "GET" and (self.request.GET.get("change") or self.request.GET.get("update")):
             self.is_bound = False
 
 

--- a/tests/test_unit/test_apply_for_a_licence/test_views/test_views_grounds_purpose.py
+++ b/tests/test_unit/test_apply_for_a_licence/test_views/test_views_grounds_purpose.py
@@ -65,3 +65,8 @@ class TestLicensingGroundsLegalAdvisoryView:
             form.form_h1_header == "For the other services you want to provide (excluding legal advisory), "
             "which of these licensing grounds describes your purpose for providing them?"
         )
+
+    def test_get_form_kwargs_update(self, al_client):
+        response = al_client.get(reverse("licensing_grounds_legal_advisory") + "?update=yes")
+        form = response.context["form"]
+        assert not form.is_bound

--- a/tests/test_unit/test_apply_for_a_licence/test_views/test_views_grounds_purpose.py
+++ b/tests/test_unit/test_apply_for_a_licence/test_views/test_views_grounds_purpose.py
@@ -1,4 +1,7 @@
-from apply_for_a_licence.choices import ProfessionalOrBusinessServicesChoices
+from apply_for_a_licence.choices import (
+    LicensingGroundsChoices,
+    ProfessionalOrBusinessServicesChoices,
+)
 from django.urls import reverse
 
 
@@ -35,6 +38,23 @@ class TestLicensingGroundsView:
         response = al_client.get(reverse("licensing_grounds"))
         form = response.context["form"]
         assert form.audit_service_selected
+
+    def test_get_success_url_legal_advisory(self, al_client):
+        session = al_client.session
+        session["professional_or_business_services"] = {
+            "professional_or_business_services": [
+                ProfessionalOrBusinessServicesChoices.legal_advisory.value,
+                ProfessionalOrBusinessServicesChoices.auditing.value,
+            ]
+        }
+        session.save()
+
+        response = al_client.post(reverse("licensing_grounds"), data={"licensing_grounds": LicensingGroundsChoices.safety.value})
+        assert response.url == reverse("licensing_grounds_legal_advisory")
+
+    def test_get_success_url_purpose_of_provision(self, al_client):
+        response = al_client.post(reverse("licensing_grounds"), data={"licensing_grounds": LicensingGroundsChoices.safety.value})
+        assert response.url == reverse("purpose_of_provision")
 
 
 class TestLicensingGroundsLegalAdvisoryView:


### PR DESCRIPTION
[Jira](https://uktrade.atlassian.net/browse/DST-720)

Unable to duplicate first bug. Appears to have been resolved by this [if statement](https://github.com/uktrade/licensing/blob/main/django_app/apply_for_a_licence/views/views_services.py#L55)

Second bug is resolved by using the update param logic and adding the query params to the success url